### PR TITLE
Updates to styling including font style and hiding GViewer toolbar buttons

### DIFF
--- a/GraphLayout/Drawing/FontStyle.cs
+++ b/GraphLayout/Drawing/FontStyle.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Msagl.Drawing
+{
+    /// <summary>
+    /// FontStyle enum
+    /// </summary>
+    [Flags]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1714:FlagsEnumsShouldHavePluralNames")]
+    public enum FontStyle
+    {
+        /// <summary>
+        ///    Normal text.
+        /// </summary>
+        Regular = 0,
+        /// <summary>
+        ///    Bold text.
+        /// </summary>
+        Bold = 1,
+        /// <summary>
+        ///    Italic text.
+        /// </summary>
+        Italic = 2,
+        /// <summary>
+        ///    Underlined text.
+        /// </summary>
+        Underline = 4,
+        /// <summary>
+        ///    Text with a line through the middle.
+        /// </summary>
+        Strikeout = 8,
+    }
+}

--- a/GraphLayout/Drawing/GraphReader.cs
+++ b/GraphLayout/Drawing/GraphReader.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Msagl.Drawing {
                     Text = ReadStringElement(Tokens.Text),
                     FontName = ReadStringElement(Tokens.FontName),
                     FontColor = ReadColorElement(Tokens.FontColor),
+                    FontStyle = (FontStyle)ReadIntElement(Tokens.FontStyle),
                     FontSize = ReadDoubleElement(Tokens.FontSize),
                     Width = ReadDoubleElement(Tokens.Width),
                     Height = ReadDoubleElement(Tokens.Height),

--- a/GraphLayout/Drawing/GraphReader.cs
+++ b/GraphLayout/Drawing/GraphReader.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Msagl.Drawing {
                     Text = ReadStringElement(Tokens.Text),
                     FontName = ReadStringElement(Tokens.FontName),
                     FontColor = ReadColorElement(Tokens.FontColor),
-                    FontStyle = (FontStyle)ReadIntElement(Tokens.FontStyle),
+                    FontStyle = TokenIs(Tokens.FontStyle) ? (FontStyle)ReadIntElement(Tokens.FontStyle) : FontStyle.Regular,
                     FontSize = ReadDoubleElement(Tokens.FontSize),
                     Width = ReadDoubleElement(Tokens.Width),
                     Height = ReadDoubleElement(Tokens.Height),

--- a/GraphLayout/Drawing/GraphWriter.cs
+++ b/GraphLayout/Drawing/GraphWriter.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Msagl.Drawing {
                 WriteStringElement(Tokens.Text, label.Text);
                 WriteStringElement(Tokens.FontName, label.FontName);
                 WriteColorElement(Tokens.FontColor, label.FontColor);
+                WriteStringElement(Tokens.FontStyle, (int)label.FontStyle);
                 WriteStringElement(Tokens.FontSize, label.FontSize);
                 WriteStringElement(Tokens.Width, label.Width);
                 WriteStringElement(Tokens.Height, label.Height);

--- a/GraphLayout/Drawing/Label.cs
+++ b/GraphLayout/Drawing/Label.cs
@@ -138,6 +138,22 @@ namespace Microsoft.Msagl.Drawing {
             }
         }
 
+        FontStyle fontStyle = FontStyle.Regular;
+
+        ///<summary>
+        ///Label font style.
+        ///</summary>
+        [Description("type face style")]
+        public FontStyle FontStyle
+        {
+            get { return fontStyle; }
+            set
+            {
+                fontStyle = value;
+            }
+        }
+
+
         ///<summary>
         ///Type face font.
         ///</summary>
@@ -161,6 +177,7 @@ namespace Microsoft.Msagl.Drawing {
 
         }
 
+        
 
 
         string text;

--- a/GraphLayout/Drawing/Tokens.cs
+++ b/GraphLayout/Drawing/Tokens.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Msagl.Drawing {
         NodeAttribute, NodeSeparation, AspectRatio, OptimizeLabelPositions, Padding,
         TransparencyOfSelectedEntityColor, SelectedEntityColor, Color, A, R, G, B,
         SelectedNodeBoundaryColor, MinNodeWidth,
-        MinNodeHeight, Border, Fillcolor, FontColor, FontName, FontSize,
+        MinNodeHeight, Border, Fillcolor, FontColor, FontStyle, FontName, FontSize,
         Label, LabelMargin, LineWidth, Shape, XRad, YRad, Styles, Style,
         BaseAttr, LabelSize, Width, Height, EdgeAttribute, EdgeSeparation, Weight, ArrowStyle, ArrowheadLength,
         GraphAttribute, BackgroundColor, Margin, MinNodeSeparation, MinLayerSeparation, LayerDirection,

--- a/GraphLayout/Drawing/drawing.csproj
+++ b/GraphLayout/Drawing/drawing.csproj
@@ -511,6 +511,7 @@
     <Compile Include="..\version.cs">
       <Link>version.cs</Link>
     </Compile>
+    <Compile Include="FontStyle.cs" />
     <Compile Include="LayerConstraints.cs" />
     <Compile Include="HorizontalConstraintsForLayeredLayout.cs" />
     <Compile Include="LayoutEditing\DraggingMode.cs" />

--- a/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
+++ b/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Msagl.Miscellaneous
         /// <exception cref="System.OperationCanceledException">Thrown when the layout is canceled.</exception>
 #endif
         public static void CalculateLayout(GeometryGraph geometryGraph, LayoutAlgorithmSettings settings, CancelToken cancelToken) {
-            Console.WriteLine("starting CalculateLayout");
             if (settings is RankingLayoutSettings) {
                 var rankingLayoutSettings = settings as RankingLayoutSettings;
                 var rankingLayout = new RankingLayout(rankingLayoutSettings, geometryGraph);

--- a/GraphLayout/tools/GraphViewerGDI/DGraph.cs
+++ b/GraphLayout/tools/GraphViewerGDI/DGraph.cs
@@ -529,7 +529,7 @@ namespace Microsoft.Msagl.GraphViewerGdi{
 
         internal static void CreateDLabel(DObject parent, Drawing.Label label, out double width, out double height,
                                           GViewer viewer){
-            var dLabel = new DLabel(parent, label, viewer){Font = new Font(label.FontName, (int)label.FontSize)};
+            var dLabel = new DLabel(parent, label, viewer){Font = new Font(label.FontName, (int)label.FontSize, (System.Drawing.FontStyle)(int)label.FontStyle)};
             StringMeasure.MeasureWithFont(label.Text, dLabel.Font, out width, out height);
 
             if (width <= 0)

--- a/GraphLayout/tools/GraphViewerGDI/DLabel.cs
+++ b/GraphLayout/tools/GraphViewerGDI/DLabel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Msagl.GraphViewerGdi {
             parent = parentPar;
             DrawingLabel = label;
             ((IHavingDLabel) parent).Label = this;
-            Font = new Font(DrawingLabel.FontName, (int)DrawingLabel.FontSize);
+            Font = new Font(DrawingLabel.FontName, (int)DrawingLabel.FontSize, (System.Drawing.FontStyle)(int)label.FontStyle);
         }
 
         /// <summary>

--- a/GraphLayout/tools/GraphViewerGDI/GViewer.cs
+++ b/GraphLayout/tools/GraphViewerGDI/GViewer.cs
@@ -1001,7 +1001,7 @@ namespace Microsoft.Msagl.GraphViewerGdi {
         void CreateNodeGeometry(DrawingNode node, Point center)
         {
             double width, height;
-            StringMeasure.MeasureWithFont(node.Label.Text, new Font(node.Label.FontName, (float)node.Label.FontSize), out width,
+            StringMeasure.MeasureWithFont(node.Label.Text, new Font(node.Label.FontName, (float)node.Label.FontSize, (System.Drawing.FontStyle)(int)node.Label.FontStyle), out width,
                                           out height);
 
             if (node.Label != null)
@@ -2281,7 +2281,7 @@ namespace Microsoft.Msagl.GraphViewerGdi {
             double height = 0;
             string label = node.Label.Text;
             if (String.IsNullOrEmpty(label) == false) {
-                var f = new Font(node.Label.FontName, (int)node.Label.FontSize);
+                var f = new Font(node.Label.FontName, (int)node.Label.FontSize, (System.Drawing.FontStyle)(int)node.Label.FontStyle);
                 StringMeasure.MeasureWithFont(label, f, out width, out height);
             }
             node.Label.Size = new Size((float) width, (float) height);

--- a/GraphLayout/tools/GraphViewerGDI/ScrollGViewer.cs
+++ b/GraphLayout/tools/GraphViewerGDI/ScrollGViewer.cs
@@ -341,6 +341,28 @@ namespace Microsoft.Msagl.GraphViewerGdi{
         }
 
         /// <summary>
+        ///hides and shows the undo/redo buttons
+        /// </summary>
+        public bool UndoRedoButtonsVisible
+        {
+            get { return undoButton.Visible; }
+            set
+            {
+                undoButton.Visible = value;
+                redoButton.Visible = value;
+            }
+        }
+
+        /// <summary>
+        ///hides and shows the edge insert button
+        /// </summary>
+        public bool EdgeInsertButtonVisible
+        {
+            get { return edgeInsertButton.Visible; }
+            set { edgeInsertButton.Visible = value; }
+        }
+
+        /// <summary>
         /// exposes the kind of the layout that is used when the graph is laid out by the viewer
         /// </summary>
         public LayoutMethod CurrentLayoutMethod{


### PR DESCRIPTION
First off, thank you so much for making MSAGL open source, and even more for changing to an MIT license! It's a great library that fills an important niche and I think developers have been avoiding it in the past because of the murky licensing and purchasing options.

This PR is a collection of styling updates.

The biggest one is the addition of font styles. I implemented it similarly to other `Node` styling in that there is now a `Microsoft.Msagl.Drawing.FontStyle` enum instead of a direct dependency on `System.Drawing`. However, I only implemented support for the new font styling within the GDI control. Implementing font styling for the WPF control will be harder because there is no single property to change. In WPF, "boldness" is handled via weight, italics is handler via the WPF `FontStyle` static class, etc.

I also added flags to hide a couple additional `GViewer` toolbar buttons.

I also removed a `Console.WriteLine()` call in `LayoutHelpers.CalculateLayout()`. This was causing problems for me because in an application using MSAGL that either traps, displays, or passes on console output, these messages start to add noise. This one was appearing constantly for me. I did notice there were several other uses of `Console.WriteLine()`, specifically in some of the layout engines - maybe those should be removed as well and a logging infrastructure put in place instead?