### PR TITLE
Use version.cs for the assembly version number for more projects that…

### DIFF
--- a/GraphLayout/MSAGL/Msagl.csproj
+++ b/GraphLayout/MSAGL/Msagl.csproj
@@ -177,6 +177,9 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\version.cs">
+      <Link>version.cs</Link>
+    </Compile>
     <Compile Include="Core\AlgorithmBase.cs" />
     <Compile Include="Core\DataStructures\CollectionUtilities.cs" />
     <Compile Include="Core\DataStructures\GenericBinaryHeapPriorityQueueWithTimestamp.cs" />

--- a/GraphLayout/MSAGL/Properties/AssemblyInfo.cs
+++ b/GraphLayout/MSAGL/Properties/AssemblyInfo.cs
@@ -33,7 +33,6 @@ using System;
 [assembly: InternalsVisibleTo("Test01, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100e3b43db620ddf9733693e320dc708264d4c96bcfabe11cac54c7fb9579327d4e083627bcd9f248423cf3cdab5dfe9f563d0596007163020c349055ce964691463bc101260caa0350aa53bdc3990ea1c17dcedb89a97fddce92c108ba23bba69f31b23393ad7b0ecc55595425285adec585786f274d854f903445b9c0676892d1")]
 
 [assembly: System.Resources.NeutralResourcesLanguage("en-us")]
-[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: CLSCompliant(true)]
 #endif
 

--- a/GraphLayout/tools/GraphmapsWpfControl/GraphmapsWpfControl.csproj
+++ b/GraphLayout/tools/GraphmapsWpfControl/GraphmapsWpfControl.csproj
@@ -87,6 +87,9 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\version.cs">
+      <Link>version.cs</Link>
+    </Compile>
     <Compile Include="ClickCounter.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="GraphmapsViewer.cs" />

--- a/GraphLayout/tools/GraphmapsWpfControl/Properties/AssemblyInfo.cs
+++ b/GraphLayout/tools/GraphmapsWpfControl/Properties/AssemblyInfo.cs
@@ -40,16 +40,3 @@ using System.Windows;
                                       // app, or any theme specific resource dictionaries)
 )]
 
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GraphLayout/tools/WpfGraphControl/Properties/AssemblyInfo.cs
+++ b/GraphLayout/tools/WpfGraphControl/Properties/AssemblyInfo.cs
@@ -69,15 +69,3 @@ using System.Windows;
 )]
 
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GraphLayout/tools/WpfGraphControl/WpfGraphControl.csproj
+++ b/GraphLayout/tools/WpfGraphControl/WpfGraphControl.csproj
@@ -87,6 +87,9 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\version.cs">
+      <Link>version.cs</Link>
+    </Compile>
     <Compile Include="ClickCounter.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="GraphViewer.cs" />


### PR DESCRIPTION
… don't use it yet in preparation for NuGet.