### PR TITLE
ReadNodePlacementAndColors

### DIFF
--- a/GraphLayout/Drawing/GraphReader.cs
+++ b/GraphLayout/Drawing/GraphReader.cs
@@ -226,6 +226,12 @@ namespace Microsoft.Msagl.Drawing {
 
         private void ReadEdges() {
             CheckToken(Tokens.Edges);
+
+            if (xmlReader.IsEmptyElement) {
+                XmlRead();
+                return;
+            }
+
             XmlRead();
             while (TokenIs(Tokens.Edge))
                 ReadEdge();

--- a/GraphLayout/Drawing/NodeAttr.cs
+++ b/GraphLayout/Drawing/NodeAttr.cs
@@ -157,6 +157,12 @@ namespace Microsoft.Msagl.Drawing {
                 RaiseVisualsChangedEvent(this, null);
             }
         }
-        
+
+        private double labelWidthToHeightRatio = 1.0;
+
+        public double LabelWidthToHeightRatio {
+            get { return labelWidthToHeightRatio; }
+            set { labelWidthToHeightRatio = value; }
+        }
     }
 }

--- a/GraphLayout/MSAGL/DebugHelpers/Persistence/GeometryGraphReader.cs
+++ b/GraphLayout/MSAGL/DebugHelpers/Persistence/GeometryGraphReader.cs
@@ -382,6 +382,11 @@ namespace Microsoft.Msagl.DebugHelpers.Persistence {
         }
 
         void ReadLgEdgeInfos(LgData lgData) {
+            if (XmlReader.IsEmptyElement) {
+                XmlRead();
+                return;
+            }
+
             XmlRead();
             while (TokenIs(GeometryToken.LgEdgeInfo))
                 ReadLgEdgeInfo(lgData);
@@ -458,6 +463,11 @@ namespace Microsoft.Msagl.DebugHelpers.Persistence {
 
 
         void ReadRailIdsPerEdgeIds(LgData lgData, Dictionary<string, Set<string>> edgeIdToEdgeRailsSet) {
+            if (XmlReader.IsEmptyElement) {
+                XmlRead();
+                return;
+            }
+            
             XmlRead();
             while (TokenIs(GeometryToken.EdgeRails))
                 ReadEdgeRailIds(lgData, edgeIdToEdgeRailsSet);
@@ -762,6 +772,12 @@ namespace Microsoft.Msagl.DebugHelpers.Persistence {
 
         void ReadEdges() {
             CheckToken(GeometryToken.Edges);
+
+            if (XmlReader.IsEmptyElement) {
+                XmlRead();
+                return;
+            }
+
             XmlRead();
             while (TokenIs(GeometryToken.Edge))
                 ReadEdge();

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgInteractor.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgInteractor.cs
@@ -1196,14 +1196,14 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout {
             FillLevelsWithNodesOnly(maxNodesPerTile);
             
             InitRailsOfEdgesEmpty();
-            InitNodeLabelWidthToHeightRatios();
+            //InitNodeLabelWidthToHeightRatios();
             AddSkeletonLevels();
             for (int i = 0; i < _lgData.Levels.Count; i++)
                 RemoveOverlapsAndRouteForLayer(maxNodesPerTile, maxSegmentsPerTile, increaseNodeQuota, i);
 
 
             _lgData.CreateLevelNodeTrees(NodeDotWidth(1));
-            LabelingOfOneRun();
+            //LabelingOfOneRun();
 #if DEBUG
             TestAllEdgesConsistency();
 #endif
@@ -1217,7 +1217,7 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout {
             return bbox;
         }
 
-        void LabelingOfOneRun() {
+        public void LabelingOfOneRun() {
             foreach (LgNodeInfo node in _lgData.SortedLgNodeInfos) {
                 //if (node.ZoomLevel > 1.0)
                 //    node.LabelVisibleFromScale = node.ZoomLevel;
@@ -1369,9 +1369,15 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout {
 #endif
         }
 
-        void InitNodeLabelWidthToHeightRatios() {
-            foreach (LgNodeInfo ni in _lgData.SortedLgNodeInfos) {
-                ni.LabelWidthToHeightRatio = ni.GeometryNode.BoundingBox.Width/ni.GeometryNode.BoundingBox.Height;
+        public void InitNodeLabelWidthToHeightRatios(List<double> noldeLabelRatios) {
+            for(int i = 0; i< _mainGeometryGraph.Nodes.Count; i++)
+            {
+                var n = _mainGeometryGraph.Nodes[i];
+                var ni = _lgData.GeometryNodesToLgNodeInfos[n];
+                if (ni != null)
+                {
+                    ni.LabelWidthToHeightRatio = noldeLabelRatios[i];
+                }
             }
         }
 

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgLayoutSettings.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgLayoutSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Msagl.Core.DataStructures;
 using Microsoft.Msagl.Core.Geometry;
 using Microsoft.Msagl.Core.Geometry.Curves;
@@ -93,6 +94,7 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout {
             MaximalArrowheadLength = maximalArrowheadLength;
             EdgeRoutingSettings.Padding = NodeSeparation/4;
             EdgeRoutingSettings.PolylinePadding = NodeSeparation/6;
+            InitDefaultRailColors();
         }
 
         public Func<Rectangle> ClientViewportMappedToGraph { get; set; }            
@@ -196,6 +198,29 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout {
         }
 
         bool _generateTiles = true;
+
+        private String[] _railColors;
+
+        public String[] RailColors {
+            get { return _railColors; }
+            set { _railColors = value; }
+        }
+
+        private void InitDefaultRailColors()
+        {
+            _railColors = new String[3];
+            _railColors[0] = "#87CEFA";
+            _railColors[1] = "#FAFAD2";
+            _railColors[2] = "#F5F5F5";
+        }
+
+        public String GetColorForZoomLevel(double zoomLevel)
+        {
+            int logZoomLevel = (int)Math.Log(zoomLevel, 2.0);
+            logZoomLevel = Math.Min(logZoomLevel, RailColors.Count() - 1);
+            logZoomLevel = Math.Max(logZoomLevel, 0);
+            return RailColors[logZoomLevel];
+        }
 
     }
 }

--- a/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
+++ b/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
@@ -86,6 +86,13 @@ namespace Microsoft.Msagl.Miscellaneous
             largeGraphLayout.Run();
         }
 
+        static public void ComputeNodeLabelsOfLargeGraphWithLayers(GeometryGraph geometryGraph, LayoutAlgorithmSettings settings, List<double> noldeLabelRatios, CancelToken cancelToken) {
+            var largeGraphLayoutSettings = (LgLayoutSettings)settings;
+            var largeGraphLayout = largeGraphLayoutSettings.Interactor;
+            largeGraphLayout.InitNodeLabelWidthToHeightRatios(noldeLabelRatios);
+            largeGraphLayout.LabelingOfOneRun();
+        }
+
         static void ProcessSugiamaLayout(GeometryGraph geometryGraph, SugiyamaLayoutSettings sugiyamaLayoutSettings, CancelToken cancelToken) {
             PlaneTransformation originalTransform;
             var transformIsNotIdentity = HandleTransformIsNotIdentity(geometryGraph, sugiyamaLayoutSettings, out originalTransform);

--- a/GraphLayout/Test/TestGraphmaps/App.cs
+++ b/GraphLayout/Test/TestGraphmaps/App.cs
@@ -80,6 +80,7 @@ namespace TestGraphmaps {
         const string ExitAfterLgLayoutOption = "-lgexit";
         const string BackgroundImageOption = "-bgimage";
         const string BackgroundColorOption = "-bgcolor";
+        const string RailColorsOption = "-railcolors";
 
         public static readonly RoutedUICommand OpenFileCommand = new RoutedUICommand("Open File...", "OpenFileCommand",
             typeof (App));
@@ -368,6 +369,15 @@ namespace TestGraphmaps {
             }
             CheckNodeQuota();
             CheckRailQuota();
+            CheckRailColors();
+        }
+
+        void CheckRailColors() {
+            string railColors = _argsParser.GetValueOfOptionWithAfterString(RailColorsOption);
+            if (railColors != null)
+            {
+                _graphViewer.DefaultLargeLayoutSettings.RailColors = railColors.Split(',');
+            }
         }
 
         void CheckRailQuota() {
@@ -512,6 +522,8 @@ namespace TestGraphmaps {
                 "sets the background image for the large layout");
             _argsParser.AddOptionWithAfterStringWithHelp(BackgroundColorOption,
     "sets the background color for the large layout viewer");
+            _argsParser.AddOptionWithAfterStringWithHelp(RailColorsOption,
+"sets the rail colors for the large layout viewer");
 
             _argsParser.AddOptionWithAfterStringWithHelp(MaxNodesPerTileOption,
                 "sets the max nodes per tile for large layout");

--- a/GraphLayout/Test/TestGraphmaps/App.cs
+++ b/GraphLayout/Test/TestGraphmaps/App.cs
@@ -79,6 +79,7 @@ namespace TestGraphmaps {
         const string NoEdgeRoutingOption = "-nr";
         const string ExitAfterLgLayoutOption = "-lgexit";
         const string BackgroundImageOption = "-bgimage";
+        const string BackgroundColorOption = "-bgcolor";
 
         public static readonly RoutedUICommand OpenFileCommand = new RoutedUICommand("Open File...", "OpenFileCommand",
             typeof (App));
@@ -191,6 +192,12 @@ namespace TestGraphmaps {
             _graphViewer.BindToPanel(_graphViewerPanel);
             _dockPanel.Loaded += GraphViewerLoaded;
             _argsParser = SetArgsParser(Args);
+
+            if (_argsParser.OptionIsUsed(BackgroundColorOption)) {
+                var bc = _argsParser.GetValueOfOptionWithAfterString(BackgroundColorOption);
+                _graphViewerPanel.Background = (SolidColorBrush)(new BrushConverter().ConvertFrom(bc));
+            }
+
             //graphViewer.MainPanel.MouseLeftButtonUp += TestApi;
             TrySettingGraphViewerLargeLayoutThresholdAndSomeOtherLgSettings();
             if (_argsParser.OptionIsUsed(ExitAfterLgLayoutOption)) {
@@ -503,6 +510,8 @@ namespace TestGraphmaps {
             _argsParser.AddOptionWithAfterStringWithHelp(LargeLayoutThresholdOption, "sets the large layout threshold");
             _argsParser.AddOptionWithAfterStringWithHelp(BackgroundImageOption,
                 "sets the background image for the large layout");
+            _argsParser.AddOptionWithAfterStringWithHelp(BackgroundColorOption,
+    "sets the background color for the large layout viewer");
 
             _argsParser.AddOptionWithAfterStringWithHelp(MaxNodesPerTileOption,
                 "sets the max nodes per tile for large layout");

--- a/GraphLayout/Test/TestGraphmaps/GexfNodeAttr.cs
+++ b/GraphLayout/Test/TestGraphmaps/GexfNodeAttr.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.Msagl.Core.Geometry;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Msagl.Core.Geometry;
 
 namespace TestGraphmaps {
     internal class GexfNodeAttr {
         internal Point Position;
         internal double Size;
+        internal Dictionary<String, String> Attvalues = new Dictionary<string, string>();
     }
 }

--- a/GraphLayout/Test/TestGraphmaps/GexfParser.cs
+++ b/GraphLayout/Test/TestGraphmaps/GexfParser.cs
@@ -132,6 +132,22 @@ namespace TestGraphmaps {
             ReadNodeFeatures(node);
         }
 
+        private void SetLabelFromAttrValues(Node node, GexfNodeAttr gexfNodeAttr)
+        {
+            if (gexfNodeAttr.Attvalues.Count > 0)
+            {
+                var first = true;
+                String labelText = "";
+                foreach (var attVal in gexfNodeAttr.Attvalues.Values)
+                {
+                    if (!first) labelText += " ";
+                    labelText += attVal;
+                    first = false;
+                }
+                node.LabelText = labelText;
+            }
+        }
+
         void ReadNodeFeatures(Node node) {
             GexfNodeAttr gexfNodeAttr;
             idsToGexfNodeAttr[node.Id] = gexfNodeAttr = new GexfNodeAttr();
@@ -139,19 +155,52 @@ namespace TestGraphmaps {
                 switch (xmlReader.Name) {
                     case "viz:color":
                         ReadColor(node);
+                        xmlReader.Read();
+                        xmlReader.ReadEndElement();
                         break;
                     case "viz:position":
                         ReadPosition(gexfNodeAttr);
+                        xmlReader.Read();
+                        xmlReader.ReadEndElement();
                         break;
                     case "viz:size":
                         ReadSize(gexfNodeAttr);
+                        xmlReader.Read();
+                        xmlReader.ReadEndElement();
+                        break;
+                    case "attvalues":
+                        ReadAttvalues(gexfNodeAttr);
                         break;
                     default:
                         xmlReader.Skip();
                         break;
                 }
-                xmlReader.Read();
+                //xmlReader.Read();
             }
+
+            SetLabelFromAttrValues(node, gexfNodeAttr);
+        }
+
+        private void ReadAttvalues(GexfNodeAttr gexfNodeAttr)
+        {
+            xmlReader.Read();
+            while (IsStartElement() && Name == "attvalue")
+            {
+                ReadAttvalue(gexfNodeAttr);
+                if(!xmlReader.IsEmptyElement)
+                    xmlReader.Read();
+                xmlReader.ReadEndElement();
+            }
+            if(Name=="attvalues")
+                xmlReader.ReadEndElement();
+        }
+
+        private void ReadAttvalue(GexfNodeAttr gexfNodeAttr)
+        {
+            var attFor = xmlReader.GetAttribute("for");
+            var attVal = xmlReader.GetAttribute("value");
+            if (attFor != null && attVal != null)
+                gexfNodeAttr.Attvalues[attFor] = attVal;
         }
 
         void ReadSize(GexfNodeAttr gexfNodeAttr) {

--- a/GraphLayout/Test/TestGraphmaps/GraphmlNode.cs
+++ b/GraphLayout/Test/TestGraphmaps/GraphmlNode.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Msagl.Core.DataStructures;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Msagl.Core.DataStructures;
 
 namespace TestGraphmaps {
     internal class GraphmlNode {
@@ -13,5 +15,7 @@ namespace TestGraphmaps {
 
         public string Pubid { get; set; }
         public string Fullname { get; set; }
+
+        public Dictionary<String,String> Data = new Dictionary<string, string>(); 
     }
 }

--- a/GraphLayout/tools/GraphmapsWpfControl/GraphmapsEdge.cs
+++ b/GraphLayout/tools/GraphmapsWpfControl/GraphmapsEdge.cs
@@ -368,10 +368,18 @@ namespace Microsoft.Msagl.GraphmapsWpfControl {
             brush = rail.IsHighlighted ? Brushes.Red.Color : Brushes.SlateGray.Color;
             if (rail.TopRankedEdgeInfoOfTheRail == null) return new SolidColorBrush(brush);
 
-            if (rail.MinPassingEdgeZoomLevel <= 1) brush = Brushes.LightSkyBlue.Color;//Brushes.DimGray.Color;
-            else if (rail.MinPassingEdgeZoomLevel <= 2)
-                brush = Brushes.LightGoldenrodYellow.Color; //Brushes.SlateGray.Color;
-            else brush = Brushes.WhiteSmoke.Color;//Brushes.Gray.Color;
+            if (lgSettings != null)
+            {
+                var col = lgSettings.GetColorForZoomLevel(rail.MinPassingEdgeZoomLevel);
+                brush = ((SolidColorBrush)(new BrushConverter().ConvertFrom(col))).Color;
+            }
+            else
+            {
+                if (rail.MinPassingEdgeZoomLevel <= 1) brush = Brushes.LightSkyBlue.Color; //Brushes.DimGray.Color;
+                else if (rail.MinPassingEdgeZoomLevel <= 2)
+                    brush = Brushes.LightGoldenrodYellow.Color; //Brushes.SlateGray.Color;
+                else brush = Brushes.WhiteSmoke.Color; //Brushes.Gray.Color;
+            }
 
             if (rail.IsHighlighted)
             {

--- a/GraphLayout/tools/GraphmapsWpfControl/GraphmapsNode.cs
+++ b/GraphLayout/tools/GraphmapsWpfControl/GraphmapsNode.cs
@@ -287,6 +287,17 @@ namespace Microsoft.Msagl.GraphmapsWpfControl {
                 BoundaryPath.Fill = Brushes.Blue;
                 return;
             }
+
+            var colBlack = new Drawing.Color(0, 0, 0);
+
+            if (!Node.Attr.Color.Equals(colBlack))
+            {
+                BoundaryPath.Fill = LgNodeInfo.Selected
+                ? Brushes.Red
+                : Common.BrushFromMsaglColor(Node.Attr.Color);
+                return;
+            }
+
             BoundaryPath.Fill = LgNodeInfo.Selected
                 ? Brushes.Red
                 : (LgNodeInfo != null && LgNodeInfo.SlidingZoomLevel == 0

--- a/GraphLayout/tools/GraphmapsWpfControl/GraphmapsViewer.cs
+++ b/GraphLayout/tools/GraphmapsWpfControl/GraphmapsViewer.cs
@@ -931,6 +931,7 @@ namespace Microsoft.Msagl.GraphmapsWpfControl {
                         NeedToLayout = NeedToCalculateLayout,
                         MaxNumberOfNodesPerTile = DefaultLargeLayoutSettings.MaxNumberOfNodesPerTile,
                         MaxNumberOfRailsPerTile = DefaultLargeLayoutSettings.MaxNumberOfRailsPerTile,
+                        RailColors = DefaultLargeLayoutSettings.RailColors,
                         ExitAfterInit = DefaultLargeLayoutSettings.ExitAfterInit,
                         SimplifyRoutes = DefaultLargeLayoutSettings.SimplifyRoutes,
                         NodeLabelHeightInInches = DefaultLargeLayoutSettings.NodeLabelHeightInInches,


### PR DESCRIPTION
Can now load .gexf files with specified node placement, label nodes by attributes and display specified node colors.