### PR TITLE
Fix code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,29 @@ using System.Windows.Forms;
 class ViewerSample { 
     public static void Main() { 
     //create a form 
-        System.Windows.Forms.Form form = new System.Windows.Forms.Form(); 
+        System.Windows.Forms.Form form = new System.Windows.Forms.Form();
     //create a viewer object 
-        Microsoft.Msagl.GraphViewerGdi.GViewer viewer = new Microsoft.Msagl.GraphViewerGdi.GViewer(); 
+        Microsoft.Msagl.GraphViewerGdi.GViewer viewer = new Microsoft.Msagl.GraphViewerGdi.GViewer();
     //create a graph object 
-        Microsoft.Msagl.Drawing.Graph graph = new Microsoft.Msagl.Drawing.Graph("graph"); 
+        Microsoft.Msagl.Drawing.Graph graph = new Microsoft.Msagl.Drawing.Graph("graph");
     //create the graph content 
         graph.AddEdge("A", "B");
-        graph.AddEdge("B", "C"); 
-        graph.AddEdge("A", "C").EdgeAttr.Color = Microsoft.Msagl.Drawing.Color.Green; 
-        graph.FindNode("A").Attr.Fillcolor = Microsoft.Msagl.Drawing.Color.Magenta; 
-        graph.FindNode("B").Attr.Fillcolor = Microsoft.Msagl.Drawing.Color.MistyRose; 
-        Microsoft.Msagl.Drawing.Node c = graph.FindNode("C");  
-        c.Attr.Fillcolor = Microsoft.Msagl.Drawing.Color.PaleGreen;
-        c.Attr.Shape = Microsoft.Msagl.Drawing.Shape.Diamond; 
+        graph.AddEdge("B", "C");
+        graph.AddEdge("A", "C").Attr.Color = Microsoft.Msagl.Drawing.Color.Green;
+        graph.FindNode("A").Attr.FillColor = Microsoft.Msagl.Drawing.Color.Magenta;
+        graph.FindNode("B").Attr.FillColor = Microsoft.Msagl.Drawing.Color.MistyRose;
+        Microsoft.Msagl.Drawing.Node c = graph.FindNode("C");
+        c.Attr.FillColor = Microsoft.Msagl.Drawing.Color.PaleGreen;
+        c.Attr.Shape = Microsoft.Msagl.Drawing.Shape.Diamond;
     //bind the graph to the viewer 
-        viewer.Graph = graph; 
+        viewer.Graph = graph;
     //associate the viewer with the form 
-        form.SuspendLayout(); 
-        viewer.Dock = System.Windows.Forms.DockStyle.Fill; 
-        form.Controls.Add(viewer); 
-        form.ResumeLayout(); 
+        form.SuspendLayout();
+        viewer.Dock = System.Windows.Forms.DockStyle.Fill;
+        form.Controls.Add(viewer);
+        form.ResumeLayout();
     //show the form 
-        form.ShowDialog(); 
+        form.ShowDialog();
     } 
 }
 ```


### PR DESCRIPTION
The code sample did not compile as-is due to a typo in capitalization of
FillColor, and due to a change of EdgeAttr to Attr.