### PR TITLE
Added conspicuously missing `Remove Node` method to Subgraphs

### DIFF
--- a/GraphLayout/Drawing/Subgraph.cs
+++ b/GraphLayout/Drawing/Subgraph.cs
@@ -123,7 +123,17 @@ namespace Microsoft.Msagl.Drawing
         {
             nodes.Insert(node);
             IsUpdated = true;
-      }
+        }
+
+        /// <summary>
+        /// Removes the node from this subgraph.
+        /// </summary>
+        /// <param name="node">The node to remove.</param>
+        public void RemoveNode(Node node)
+        {
+            nodes.Remove(node);
+            IsUpdated = true;
+        }
 
         ///<summary>
         ///</summary>


### PR DESCRIPTION
Added a method `RemoveNode` to `Subgraph` that allows one to remove a node that has been added to a `Subgraph`.

This allows you to move a `Node` from one `Subgraph` to another.