### PR TITLE
Add dotted and dashed edges to SVG output

### DIFF
--- a/GraphLayout/Drawing/SvgGraphWriter.cs
+++ b/GraphLayout/Drawing/SvgGraphWriter.cs
@@ -406,9 +406,10 @@ namespace Microsoft.Msagl.Drawing
             WriteAttribute("stroke", MsaglColorToSvgColor(attr.Color));
             WriteAttribute("stroke-opacity", MsaglColorToSvgOpacity(attr.Color));
             WriteAttribute("stroke-width", attr.LineWidth);
-            if (attr.Styles.Any(style => style == Style.Dashed))
-            {
+            if (attr.Styles.Any(style => style == Style.Dashed)) {
                 WriteAttribute("stroke-dasharray", 5);
+            } else if (attr.Styles.Any(style => style == Style.Dotted)) {
+                WriteAttribute("stroke-dasharray", 2);
             }
         }
 

--- a/GraphLayout/Drawing/SvgGraphWriter.cs
+++ b/GraphLayout/Drawing/SvgGraphWriter.cs
@@ -406,6 +406,10 @@ namespace Microsoft.Msagl.Drawing
             WriteAttribute("stroke", MsaglColorToSvgColor(attr.Color));
             WriteAttribute("stroke-opacity", MsaglColorToSvgOpacity(attr.Color));
             WriteAttribute("stroke-width", attr.LineWidth);
+            if (attr.Styles.Any(style => style == Style.Dashed))
+            {
+                WriteAttribute("stroke-dasharray", 5);
+            }
         }
 
         void WriteCurve(Curve curve, Node node)


### PR DESCRIPTION
For edges with a dotted or dashed style I added output to use the SVG stroke-dasharray. This gives results more consistent with other viewers.