### PR TITLE
fixed System.OutOfMemoryException when clicking on zoomin button of GViewer

### DIFF
--- a/GraphLayout/tools/GraphViewerGDI/GViewer.cs
+++ b/GraphLayout/tools/GraphViewerGDI/GViewer.cs
@@ -1752,8 +1752,13 @@ namespace Microsoft.Msagl.GraphViewerGdi {
         /// Zooms in
         /// </summary>
         public void ZoomInPressed() {
+            double zoomFractionLocal = ZoomF * ZoomFactor();
+            var scale = CurrentScale * zoomFractionLocal;
+            var d = OriginalGraph != null ? OriginalGraph.BoundingBox.Diagonal : 0;
+            if (d * scale < 5 || d * scale > HugeDiagonal)
+                return;
             ZoomF *= ZoomFactor();
-        }
+    }
 
         /// <summary>
         /// Zooms out


### PR DESCRIPTION
GViewer cause and outofmemory exception when clicking on zoomin of a graph too many times.