### PR TITLE
PresentationCore dependencies are removed from some parts of MSAGL

### DIFF
--- a/GraphLayout/Drawing/drawing.csproj
+++ b/GraphLayout/Drawing/drawing.csproj
@@ -496,7 +496,6 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/GraphLayout/MSAGL/Core/Layout/Edge.cs
+++ b/GraphLayout/MSAGL/Core/Layout/Edge.cs
@@ -2,9 +2,7 @@ using System;
 using Microsoft.Msagl.Core.Geometry;
 using Microsoft.Msagl.Core.Geometry.Curves;
 using System.Collections.Generic;
-#if !NETCORE
-using System.Windows.Media;
-#endif
+using SolidColorBrush = System.Drawing.Brush;
 
 namespace Microsoft.Msagl.Core.Layout {
     /// <summary>

--- a/GraphLayout/MSAGL/Core/Layout/LgNodeInfo.cs
+++ b/GraphLayout/MSAGL/Core/Layout/LgNodeInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using SolidColorBrush = System.Drawing.Brush;
 using Microsoft.Msagl.Core.DataStructures;
 using Microsoft.Msagl.Core.Geometry;
 using Microsoft.Msagl.Core.Geometry.Curves;
@@ -63,7 +64,7 @@ namespace Microsoft.Msagl.Core.Layout {
 
         public LabelPlacement LabelPosition = LabelPlacement.Top;
 #if !NETCORE
-        public System.Windows.Media.SolidColorBrush Color;
+        public SolidColorBrush Color;
 #endif
 
         public enum LabelPlacement

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgData.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgData.cs
@@ -5,8 +5,8 @@ using System.Diagnostics;
 using System.Linq;
 #if !NETCORE
 using System.Runtime.Remoting.Messaging;
-using System.Windows.Media;
 #endif
+using SolidColorBrush = System.Drawing.Brush;
 using Microsoft.Msagl.Core.DataStructures;
 using Microsoft.Msagl.Core.Geometry;
 using Microsoft.Msagl.Core.Geometry.Curves;

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgInteractor.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/LgInteractor.cs
@@ -32,8 +32,9 @@ using Microsoft.Msagl.Miscellaneous.RegularGrid;
 using Microsoft.Msagl.Miscellaneous.Routing;
 using Microsoft.Msagl.Routing.Visibility;
 #if !NETCORE
-using Brushes = System.Windows.Media.Brushes;
+using Brushes = System.Drawing.Brushes;
 #endif
+using SolidColorBrush = System.Drawing.Brush;
 using Edge = Microsoft.Msagl.Core.Layout.Edge;
 using LineSegment = Microsoft.Msagl.Core.Geometry.Curves.LineSegment;
 using Point = Microsoft.Msagl.Core.Geometry.Point;

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/NodeRailLevelCalculator/GreedyNodeRailLevelCalculator.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/NodeRailLevelCalculator/GreedyNodeRailLevelCalculator.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Msagl.Layout.LargeGraphLayout.NodeRailLevelCalculator {
             }
             str += "</group>";
 #if !SILVERLIGHT && !SHARPKIT && !NETCORE
-            System.Windows.Clipboard.SetText(str);
+            System.Windows.Forms.Clipboard.SetText(str);
 #endif
         }
 

--- a/GraphLayout/MSAGL/Layout/LargeGraphLayout/Rail.cs
+++ b/GraphLayout/MSAGL/Layout/LargeGraphLayout/Rail.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-#if !NETCORE
-using System.Windows.Media;
-#endif
+using SolidColorBrush = System.Drawing.Brush;
 using Microsoft.Msagl.Core.DataStructures;
 using Microsoft.Msagl.Core.Geometry;
 using Microsoft.Msagl.Core.Geometry.Curves;

--- a/GraphLayout/MSAGL/Msagl.csproj
+++ b/GraphLayout/MSAGL/Msagl.csproj
@@ -167,7 +167,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -383,7 +382,7 @@
     <Compile Include="Routing\Spline\Bundling\Intersections.cs" />
     <Compile Include="Routing\Spline\Bundling\LinearMetroMapOrdering.cs" />
     <Compile Include="Routing\Spline\Bundling\MetroGraphData.cs" />
-    <Compile Include="Routing\Spline\Bundling\Metroline.cs" />
+    <Compile Include="Routing\Spline\Bundling\MetroLine.cs" />
     <Compile Include="Routing\Spline\Bundling\MetroNodeInfo.cs" />
     <Compile Include="Routing\Spline\Bundling\NodePositionsAdjuster.cs" />
     <Compile Include="Routing\Spline\Bundling\OrientedHubSegment.cs" />


### PR DESCRIPTION
I needed to compile MSAGL by Mono, so I had to remove some dependencies on PresentationCore.dll.
That was using `System.Windows.Media.SolidColorBrush`, `System.Windows.Media.Brushes` and
`System.Windows.Clipboard`. I replaced them by `System.Drawing.Brush`, `System.Drawing.Brushes` and `System.Windows.Forms.Clipboard` respectively.

Also I change wrong name of `MetroLine` class in `Msagl.cproj` file.
