### PR TITLE
included lib/netstandard2.0 assemblies in nuspecs

### DIFF
--- a/GraphLayout/MSAGL/Layout/Layered/SmoothedPolylineCalculator.cs
+++ b/GraphLayout/MSAGL/Layout/Layered/SmoothedPolylineCalculator.cs
@@ -11,10 +11,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Reflection.Emit;
 using Microsoft.Msagl.Layout.MDS;
-#if !SHARPKIT
-using System.IO.Packaging;
-#endif
-using System.Diagnostics.Eventing.Reader;
 
 namespace Microsoft.Msagl.Layout.Layered {
 

--- a/GraphLayout/NuGet/Microsoft.Msagl.Drawing.nuspec
+++ b/GraphLayout/NuGet/Microsoft.Msagl.Drawing.nuspec
@@ -20,7 +20,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="..\Drawing\bin\release\Microsoft.Msagl.Drawing.dll" target="lib\net40" />
-    <file src="..\Drawing\bin\release\Microsoft.Msagl.Drawing.xml" target="lib\net40" />
+    <file src="../Drawing/bin/release/Microsoft.Msagl.Drawing.dll" target="lib/net40" />
+    <file src="../Drawing/bin/release/Microsoft.Msagl.Drawing.xml" target="lib/net40" />
+    <file src="../MSAGL.NETCore/Drawing/bin/Release/netstandard2.0/MSAGL.NETCore.Drawing.dll" target="lib/netstandard2.0" />
   </files>
 </package>

--- a/GraphLayout/NuGet/Microsoft.Msagl.nuspec
+++ b/GraphLayout/NuGet/Microsoft.Msagl.nuspec
@@ -19,7 +19,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="..\MSAGL\bin\release\Microsoft.Msagl.dll" target="lib\net40" />
-    <file src="..\MSAGL\bin\release\Microsoft.Msagl.xml" target="lib\net40" />
+    <file src="../MSAGL/bin/release/Microsoft.Msagl.dll" target="lib/net40" />
+    <file src="../MSAGL/bin/release/Microsoft.Msagl.xml" target="lib/net40" />
+    <file src="../MSAGL.NETCore/MSAGL/bin/Release/netstandard2.0/MSAGL.NETCore.dll" target="lib/netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
Hello,

Are you interested in an update for the .nuspec files including the dotnet core assemblies?
I'm currently using MSAGL in an Avalonia-based software and I had to generate the nupkg with netstandard assemblies.

NB: for some reason I did not try to explain, I had to remove a couple of "using" in SmoothedPolylineCalculator.cs in order to generate the dotnet core assemblies.

Regards,
Olivier