### PR TITLE
Fix slow label dragging for newly added edges

### DIFF
--- a/GraphLayout/tools/GraphViewerGDI/GViewer.cs
+++ b/GraphLayout/tools/GraphViewerGDI/GViewer.cs
@@ -1050,6 +1050,7 @@ namespace Microsoft.Msagl.GraphViewerGdi {
       edge.Label = label;
       double w, h;
       DGraph.CreateDLabel(de, label, out w, out h, this);
+      layoutEditor.AttachLayoutChangeEvent(de.Label);
       edge.GeometryEdge.Label = label.GeometryLabel;
       ICurve curve = edge.GeometryEdge.Curve;
       label.GeometryLabel.Center = curve[(curve.ParStart + curve.ParEnd) / 2];


### PR DESCRIPTION
This commit should fix freezes while dragging text labels for edges added to the graph via GViewer.
It works the same way as the fix for dragging nodes. Please check