### PR TITLE
live select objects for dragging

### DIFF
--- a/GraphLayout/Drawing/LayoutEditing/LayoutEditor.cs
+++ b/GraphLayout/Drawing/LayoutEditing/LayoutEditor.cs
@@ -632,6 +632,8 @@ namespace Microsoft.Msagl.Drawing {
                         DragSomeObjects(e);
                     else if (InsertingEdge)
                         MouseMoveWhenInsertingEdgeAndPressingLeftButton(e);
+                    else
+                        MouseMoveLiveSelectObjectsForDragging(e);
                 } else if(InsertingEdge)
                     HandleMouseMoveWhenInsertingEdgeAndNotPressingLeftButton(e);
             }            
@@ -878,11 +880,6 @@ namespace Microsoft.Msagl.Drawing {
                 else
                     InsertEdgeOnMouseUp();
                 args.Handled = true;
-            }
-            else if (LeftMouseButtonWasPressed) {
-                if (ToggleEntityPredicate(viewer.ModifierKeys, PressedMouseButtons, true) &&
-                    (viewer.ModifierKeys & ModifierKeys.Shift) != ModifierKeys.Shift)
-                    SelectEntitiesForDraggingWithRectangle(args);
             }
             Dragging = false;
             geomGraphEditor.ForgetDragging();
@@ -1264,6 +1261,12 @@ namespace Microsoft.Msagl.Drawing {
                 }
                 e.Handled = true;
             }
+        }
+        void MouseMoveLiveSelectObjectsForDragging(MsaglMouseEventArgs e) {
+            UnselectEverything();
+            if (ToggleEntityPredicate(viewer.ModifierKeys, PressedMouseButtons, true) &&
+                (viewer.ModifierKeys & ModifierKeys.Shift) != ModifierKeys.Shift)
+                SelectEntitiesForDraggingWithRectangle(e);
         }
 
         void DrawEdgeInteractivelyToLocation(MsaglMouseEventArgs e) {


### PR DESCRIPTION
Thanks for a fine library!

This PR aims to give visual feedback during layout-editing when selecting nodes by dragging a rectangle. Nodes get selected/unselected in MouseMoveEvent as opposed to only in the end when MouseUpEvent fires. Works in demoapp so unless there is some scenario that I have not thought about it could hopefully be merged in.