### PR TITLE
Settings per Cluster for SugiyamaLayoutSettings

### DIFF
--- a/GraphLayout/MSAGL/Layout/Layered/SugiyamaLayoutSettings.cs
+++ b/GraphLayout/MSAGL/Layout/Layered/SugiyamaLayoutSettings.cs
@@ -437,5 +437,9 @@ namespace Microsoft.Msagl.Layout.Layered {
             set { gridSizeByX = value; }
         }
 
+        /// <summary>
+        /// Settings per Cluster for InitialLayoutByCluster used by LayoutHelpers.ProcessSugiamaLayout
+        /// </summary>
+        public Dictionary<object, LayoutAlgorithmSettings> ClusterSettings { get; set; } = new Dictionary<object, LayoutAlgorithmSettings>();
     }
 }

--- a/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
+++ b/GraphLayout/MSAGL/Miscellaneous/LayoutHelpers.cs
@@ -89,7 +89,13 @@ namespace Microsoft.Msagl.Miscellaneous {
 
             if (geometryGraph.RootCluster.Clusters.Any()) {
                 PrepareGraphForInitialLayoutByCluster(geometryGraph, sugiyamaLayoutSettings);
-                var initialBc = new InitialLayoutByCluster(geometryGraph, a => sugiyamaLayoutSettings);
+                var initialBc = 
+                    new InitialLayoutByCluster(
+                        geometryGraph, 
+                        //use different settings per each Cluster if available
+                        c => sugiyamaLayoutSettings.ClusterSettings.ContainsKey(c.UserData) 
+                                 ? sugiyamaLayoutSettings.ClusterSettings[c.UserData] 
+                                 : sugiyamaLayoutSettings);
                 initialBc.Run(cancelToken);
                 //route the rest of the edges, those between the clusters
                 var edgesToRoute = sugiyamaLayoutSettings.EdgeRoutingSettings.EdgeRoutingMode == EdgeRoutingMode.SplineBundling ? geometryGraph.Edges.ToArray() : geometryGraph.Edges.Where(e => e.Curve == null).ToArray();

--- a/GraphLayout/Samples/WpfApplicationSample/WpfApplicationSample.cs
+++ b/GraphLayout/Samples/WpfApplicationSample/WpfApplicationSample.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,8 +8,10 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using Microsoft.Msagl.Core.Geometry.Curves;
 using Microsoft.Msagl.Core.Routing;
 using Microsoft.Msagl.Drawing;
+using Microsoft.Msagl.Layout.Layered;
 using Microsoft.Msagl.WpfGraphControl;
 using Microsoft.Win32;
 using Color = Microsoft.Msagl.Drawing.Color;
@@ -295,8 +297,7 @@ namespace WpfApplicationSample
 
 
                 var subgraph = new Subgraph("subgraph1");
-                subgraph.Label.Text = "Outer Subgraph";
-                subgraph.Attr.ClusterLabelMargin = LabelPlacement.Bottom;
+                subgraph.Label.Text = "Outer";
                 graph.RootSubgraph.AddSubgraph(subgraph);
                 subgraph.AddNode(graph.FindNode("47"));
                 subgraph.AddNode(graph.FindNode("58"));
@@ -305,7 +306,7 @@ namespace WpfApplicationSample
                 subgraph2.Label.Text = "Inner";
                 subgraph2.Attr.Color = Color.Black;
                 subgraph2.Attr.FillColor = Color.Yellow;
-                subgraph2.Attr.ClusterLabelMargin = LabelPlacement.Left;
+                subgraph2.Attr.ClusterLabelMargin = LabelPlacement.Bottom;
                 subgraph2.AddNode(graph.FindNode("70"));
                 subgraph2.AddNode(graph.FindNode("71"));
                 subgraph.AddSubgraph(subgraph2);
@@ -313,6 +314,13 @@ namespace WpfApplicationSample
 
                 graph.Attr.LayerDirection = LayerDirection.LR;
                 //graph.LayoutAlgorithmSettings.EdgeRoutingSettings.EdgeRoutingMode = EdgeRoutingMode.Rectilinear;
+                
+                var global = (SugiyamaLayoutSettings) graph.LayoutAlgorithmSettings;
+                var local  = (SugiyamaLayoutSettings) global.Clone();
+                local.Transformation = PlaneTransformation.Rotation(-Math.PI / 2);
+                subgraph2.LayoutSettings = local;   // for Collapsing\Expanding
+                global.ClusterSettings.Add(subgraph2, local);
+
                 graphViewer.Graph = graph;
             }
             catch (Exception e)


### PR DESCRIPTION
Implementation for #80.

Need to assign `LayerDirection` per Cluster. 
Actually in my case, just `Left-Right` direction to `RootCluster` and `Top-Bottom` inside rest Clusters (opposite to directions in #80).
Have | Want
-|-
![image](https://user-images.githubusercontent.com/5301844/169706094-0bada494-d75d-4579-b827-46b744a4b09f.png) | ![image](https://user-images.githubusercontent.com/5301844/169706067-ffceb8aa-7e9b-411a-add4-7fd060c62016.png)

Family of `LayerConstraints` methods seems to not work with Clusters. Neither applied to Clusters nor to Nodes directly.
```cs
  graph.Attr.LayerDirection = LayerDirection.TB;

  graph.LayerConstraints.AddSameLayerNeighbors(
      subgraph1,
      subgraph2;

  graph.LayerConstraints.AddSameLayerNeighbors(
      graph.FindNode("58"),
      graph.FindNode("70"));

  graph.LayerConstraints.AddUpDownVerticalConstraint(
      graph.FindNode("70"),
      graph.FindNode("71"));
```