### PR TITLE
Constraints with Clusters

### DIFF
--- a/GraphLayout/Samples/WpfApplicationSample/WpfApplicationSample.cs
+++ b/GraphLayout/Samples/WpfApplicationSample/WpfApplicationSample.cs
@@ -312,14 +312,15 @@ namespace WpfApplicationSample
                 subgraph.AddSubgraph(subgraph2);
                 graph.AddEdge("58", subgraph2.Id);
 
-                graph.Attr.LayerDirection = LayerDirection.LR;
+                //graph.Attr.LayerDirection = LayerDirection.LR;
                 //graph.LayoutAlgorithmSettings.EdgeRoutingSettings.EdgeRoutingMode = EdgeRoutingMode.Rectilinear;
-                
-                var global = (SugiyamaLayoutSettings) graph.LayoutAlgorithmSettings;
-                var local  = (SugiyamaLayoutSettings) global.Clone();
-                local.Transformation = PlaneTransformation.Rotation(-Math.PI / 2);
-                subgraph2.LayoutSettings = local;   // for Collapsing\Expanding
-                global.ClusterSettings.Add(subgraph2, local);
+
+                graph.LayerConstraints.AddSameLayerNeighbors(
+                    graph.FindNode("47"),
+                    graph.FindNode("58"));
+                graph.LayerConstraints.AddSameLayerNeighbors(
+                    graph.FindNode("70"),
+                    graph.FindNode("71"));
 
                 graphViewer.Graph = graph;
             }


### PR DESCRIPTION
Explored this during #317. Decided to save the progress for future despite don't know how to complete this PR.

#

Messing with `SugiyamaLayoutSettings.Transformation` was kinda overcomplicated for such trivial goal in #317. A better solution would be to fix `LayerConstraints` to make them work with `Nodes` inside `Clusters` (and maybe even `Clusters` themselves).

Exploration has shown next sequence of usage
```fs
SugiyamaLayoutSettings
    🡇
InitialLayoutByCluster
    🡇
InitialLayoutByCluster.GetComponents
// Creates a shallow copy of the root cluster and divides into GeometryGraphs
// each of which is a connected component with respect to edges internal to root.
    🡇
InitialLayoutByCluster.ShallowNodeCopyDictionary
// Copy the cluster's child Nodes and Clusters as nodes and return a mapping of original to copy.
// The reverse mapping (copy to original) is available via the copy's UserData
```
`GetComponents` wraps each node into `new Node()`. This is the reason of the bug since constraints are added against original `Nodes`
```cs
graph.LayerConstraints.AddSameLayerNeighbors(
    graph.FindNode("47"),
    graph.FindNode("58"));
```
then used by
https://github.com/microsoft/automatic-graph-layout/blob/d20210ecfc62fc08a17ab17fd934201b5c6652ea/GraphLayout/MSAGL/Layout/Layered/HorizontalConstraintsForSugiyama.cs#L144-L150
so the method
https://github.com/microsoft/automatic-graph-layout/blob/d20210ecfc62fc08a17ab17fd934201b5c6652ea/GraphLayout/MSAGL/Layout/Layered/HorizontalConstraintsForSugiyama.cs#L98-L102
always returns `-1` since `node` is an original `Node` while `nodeIdToIndex` was built against wrapped `Nodes` (in `GetComponents`). As result lists of constraints are always empty.