### PR TITLE
Package net461 assembly as net461, not net61

### DIFF
--- a/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
+++ b/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
@@ -26,7 +26,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="./bin/Release/net461/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net61" />
+    <file src="./bin/Release/net461/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net461" />
     <file src="./bin/Release/net472/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net472" />
     <file src="./bin/Release/netcoreapp3.1/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\netcoreapp3.1" />
   </files>


### PR DESCRIPTION
I suspect this was just a typo, but currently the .NET Framework 4.6.1-built assembly for GraphViewerGDI is packaged at "net61". [There is no such thing as `net61`](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks). This is very confusing when looking at the supported frameworks [on nuget.org](https://www.nuget.org/packages/AutomaticGraphLayout.GraphViewerGDI/1.1.12).

![image](https://user-images.githubusercontent.com/1670176/180773957-93b3bfc3-5520-4333-8af5-f2d8361e454c.png)

Unsure whether fixing this constitutes a breaking change or not - given you're "dropping support" for a framework that doesn't really exist. [The '`net61`' assembly should not be selected by nuget in any currently supported versions of .NET](https://nugettools.azurewebsites.net/6.0.0/get-nearest-framework?project=net6.0&package=net61%0D%0Anet472%0D%0Anetstandard20).

However this is absolutely worth fixing - since the existing package is likely to break _really badly_ when people start [pulling it into `net70` applications](https://nugettools.azurewebsites.net/6.0.0/get-nearest-framework?project=net7.0&package=net61%0D%0Anet472%0D%0Anetstandard20).