### PR TITLE
fix NullReferenceException in Graph.RemoveNode()

### DIFF
--- a/GraphLayout/Drawing/Graph.cs
+++ b/GraphLayout/Drawing/Graph.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Msagl.Drawing {
             foreach (Edge e in delendi)
                 RemoveEdge(e);
             NodeMap.Remove(node.Id);
-            GeometryGraph.Nodes.Remove(node.GeometryObject as Core.Layout.Node);
+            GeometryGraph?.Nodes.Remove(node.GeometryObject as Core.Layout.Node);
         }
 
         /// <summary>


### PR DESCRIPTION
GeometryGraph can be null if no geometry was ever created for the graph.