### PR TITLE
Updating versioning and NuGet specs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,15 @@
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\Key.snk</AssemblyOriginatorKeyFile>
+    <Deterministic>true</Deterministic>
+    <PackageProjectUrl>https://github.com/Microsoft/automatic-graph-layout</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Microsoft/automatic-graph-layout</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>Microsoft</Authors>
+    <PackageTags>MSAGL Graph Layout</PackageTags>
+    <PackageVersion>1.1.7</PackageVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft</Authors>
     <PackageTags>MSAGL Graph Layout</PackageTags>
-    <PackageVersion>1.1.7</PackageVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/GraphLayout/Drawing/AutomaticGraphLayout.Drawing.csproj
+++ b/GraphLayout/Drawing/AutomaticGraphLayout.Drawing.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <NuspecFile>AutomaticGraphLayout.Drawing.nuspec</NuspecFile>
+    <AssemblyName>Microsoft.Msagl.Drawing</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -12,10 +13,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="AutomaticGraphLayout.Drawing.nuspec" />
+    <None Include="AutomaticGraphLayout.Drawing.nuspec" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MSAGL\AutomaticGraphLayout.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/GraphLayout/Drawing/AutomaticGraphLayout.Drawing.nuspec
+++ b/GraphLayout/Drawing/AutomaticGraphLayout.Drawing.nuspec
@@ -1,10 +1,10 @@
 ﻿<package>
   <metadata>
-    <id>AutomaticGraphLayout.Drawing</id>
-    <version>1.1.4</version>
-    <authors>paulovila</authors>
+    <id>Microsoft.Msagl.Drawing</id>
+    <version>1.1.6</version>
+    <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/automatic-graph-layout/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/automatic-graph-layout</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>The Definitions of different drawing attributes like colors, line styles, etc. It also contains definitions of a node class, an edge class, and a graph class. By using these classes a user can create a graph object and use it later for layout, and rendering.</description>
@@ -14,10 +14,11 @@
     <language>en-US</language>
     <tags>MSAGL Graph Layout</tags>
     <dependencies>
-      <dependency id="Microsoft.AutomaticGraphLayout" version="$(BuildVersion)" />
+      <dependency id="Microsoft.Msagl" version="1.1.6" />
     </dependencies>
   </metadata>
   <files>
-    <file src="./bin/Release/netstandard2.0/AutomaticGraphLayout.Drawing.dll" target="lib/netstandard2.0" />
+    <file src="./bin/Release/netstandard2.0/Microsoft.Msagl.Drawing.dll" target="lib/netstandard2.0" />
+    <file src="./bin/Release/netstandard2.0/Microsoft.Msagl.Drawing.xml" target="lib/netstandard2.0" />
   </files>
 </package>

--- a/GraphLayout/MSAGL/AutomaticGraphLayout.csproj
+++ b/GraphLayout/MSAGL/AutomaticGraphLayout.csproj
@@ -1,17 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <DefineConstants>TEST_MSAGL</DefineConstants>
+    <NuspecFile>AutomaticGraphLayout.nuspec</NuspecFile>
+    <AssemblyName>Microsoft.Msagl</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>TEST_MSAGL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="AutomaticGraphLayout.nuspec" />
+    <None Include="AutomaticGraphLayout.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/GraphLayout/MSAGL/AutomaticGraphLayout.csproj
+++ b/GraphLayout/MSAGL/AutomaticGraphLayout.csproj
@@ -7,6 +7,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TEST_MSAGL</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>TEST_MSAGL</DefineConstants>
   </PropertyGroup>

--- a/GraphLayout/MSAGL/AutomaticGraphLayout.nuspec
+++ b/GraphLayout/MSAGL/AutomaticGraphLayout.nuspec
@@ -1,10 +1,10 @@
 ﻿<package>
   <metadata>
-    <id>AutomaticGraphLayout</id>
-    <version>1.1.4</version>
-    <authors>paulovila</authors>
+    <id>Microsoft.Msagl</id>
+    <version>1.1.6</version>
+    <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/automatic-graph-layout/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/automatic-graph-layout</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This .NET assembly contains the core MSAGL layout functionality. Use this library if you just want MSAGL to perform the layout only and afterwards you will use a separate tool to perform the rendering and visualization.</description>
@@ -19,6 +19,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="./bin/release/netstandard2.0/AutomaticGraphLayout.dll" target="lib/netstandard2.0" />
+    <file src="./bin/release/netstandard2.0/Microsoft.Msagl.dll" target="lib/netstandard2.0" />
+    <file src="./bin/release/netstandard2.0/Microsoft.Msagl.xml" target="lib/netstandard2.0" />
   </files>
 </package>

--- a/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.csproj
+++ b/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.csproj
@@ -22,6 +22,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <NuspecFile>GraphViewerGDI.nuspec</NuspecFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;TEST_MSAGL</DefineConstants>
@@ -203,6 +205,10 @@
     <ProjectReference Include="..\..\MSAGL\AutomaticGraphLayout.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
+++ b/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
@@ -1,8 +1,8 @@
 <package>
   <metadata>
-    <id>AutomaticGraphLayout.GraphViewerGDI</id>
-    <version>1.1.5</version>
-    <authors>paulovila</authors>
+    <id>Microsoft.Msagl.GraphViewerGDI</id>
+    <version>1.1.6</version>
+    <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/automatic-graph-layout</projectUrl>
@@ -15,27 +15,30 @@
     <tags>MSAGL Graph Layout</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.7.2" >
-        <dependency id="AutomaticGraphLayout.Drawing" version="$(BuildVersion)" />
+        <dependency id="Microsoft.Msagl.Drawing" version="1.1.6" />
       </group>
-      <group targetFramework="net6.0-windows">
-        <dependency id="AutomaticGraphLayout.Drawing" version="$(BuildVersion)" />
+      <group targetFramework="net6.0-windows7.0">
+        <dependency id="Microsoft.Msagl.Drawing" version="1.1.6" />
       </group>
-      <group targetFramework="net7.0-windows">
-        <dependency id="AutomaticGraphLayout.Drawing" version="$(BuildVersion)" />
+      <group targetFramework="net7.0-windows7.0">
+        <dependency id="Microsoft.Msagl.Drawing" version="1.1.6" />
       </group>
     </dependencies>
     <frameworkReferences>
-      <group targetFramework="net6.0-windows">
+      <group targetFramework="net6.0-windows7.0">
         <frameworkReference name="Microsoft.WindowsDesktop.App.WinForms" />
       </group>
-      <group targetFramework="net7.0-windows">
+      <group targetFramework="net7.0-windows7.0">
         <frameworkReference name="Microsoft.WindowsDesktop.App.WinForms" />
       </group>
     </frameworkReferences>
   </metadata>
   <files>
     <file src="./bin/Release/net472/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net472" />
-    <file src="./bin/Release/net6.0-windows/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net6.0-windows" />
-    <file src="./bin/Release/net7.0-windows/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net7.0-windows" />
+    <file src="./bin/Release/net472/Microsoft.Msagl.GraphViewerGdi.xml" target="lib\net472" />
+    <file src="./bin/Release/net6.0-windows/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net6.0-windows7.0" />
+    <file src="./bin/Release/net6.0-windows/Microsoft.Msagl.GraphViewerGdi.xml" target="lib\net6.0-windows7.0" />
+    <file src="./bin/Release/net7.0-windows/Microsoft.Msagl.GraphViewerGdi.dll" target="lib\net7.0-windows7.0" />
+    <file src="./bin/Release/net7.0-windows/Microsoft.Msagl.GraphViewerGdi.xml" target="lib\net7.0-windows7.0" />
   </files>
 </package>


### PR DESCRIPTION
As part of publishing new NuGet packages that support .NET 6 and 7 (after #337 ), I found I also need to update the versioning information and a few names that are stale in NuGet specs.

As I did this, I enabled ReproducibleBuilds so these packages get source link, embedded untracked sources for debuggability, and embedded repo URLs and so on.