### PR TITLE
Add File Type Support When Open File and Update Test Project to NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,4 @@ jobs:
         uses: Malcolmnixon/Setup-VSTest@v4
 
       - name : Test
-        run: vstest.console GraphLayout\Test\MSAGLTests\bin\Debug\net6.0-windows\Microsoft.Msagl.UnitTests.dll
+        run: vstest.console GraphLayout\Test\MSAGLTests\bin\Debug\net8.0-windows\Microsoft.Msagl.UnitTests.dll

--- a/GraphLayout/Samples/LoadingDgmlGraph/Program.cs
+++ b/GraphLayout/Samples/LoadingDgmlGraph/Program.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using System;
 using Microsoft.Msagl.Drawing;
 using Microsoft.Msagl.Layout.Incremental;
 using Microsoft.Msagl.Layout.Layered;
@@ -7,6 +8,7 @@ using Microsoft.Msagl.Layout.MDS;
 
 namespace LoadingDgmlGraph {
     class Program {
+        [STAThread]
         static void Main(string[] args) {
             Microsoft.Msagl.GraphViewerGdi.DisplayGeometryGraph.SetShowFunctions();
             //create a form

--- a/GraphLayout/Test/MSAGLTests/MSAGLTests.csproj
+++ b/GraphLayout/Test/MSAGLTests/MSAGLTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     
     <AssemblyName>Microsoft.Msagl.UnitTests</AssemblyName>

--- a/GraphLayout/Test/TestFormForGViewer/TestFormForGViewer.csproj
+++ b/GraphLayout/Test/TestFormForGViewer/TestFormForGViewer.csproj
@@ -13,6 +13,7 @@
 	
 	<ItemGroup>
 		<ProjectReference Include="..\..\Drawing\AutomaticGraphLayout.Drawing.csproj" />
+		<ProjectReference Include="..\..\tools\DgmlParser\DgmlParser.csproj" />
 		<ProjectReference Include="..\..\tools\GraphViewerGDI\GraphViewerGDI.csproj" />
 		<ProjectReference Include="..\..\MSAGL\AutomaticGraphLayout.csproj" />
 		<ProjectReference Include="..\..\tools\Dot2Graph\Dot2Graph.csproj" />

--- a/GraphLayout/Test/TestGraphmaps/TestGraphmaps.csproj
+++ b/GraphLayout/Test/TestGraphmaps/TestGraphmaps.csproj
@@ -4,7 +4,7 @@
 		<OutputType>WinExe</OutputType>
 		<RootNamespace>TestGraphmaps</RootNamespace>
 		<AssemblyName>TestGraphmaps</AssemblyName>
-		<TargetFrameworks>net6.0-windows</TargetFrameworks>
+		<TargetFrameworks>net8.0-windows</TargetFrameworks>
 		<UseWPF>true</UseWPF>
 		<NoWarn>CS8618;CS8603</NoWarn>
 		


### PR DESCRIPTION
Support msagl, dot, dmgl.  Then we can enrich it to one viewer/editor based on current test01.