### PR TITLE
Fix misspelled WinForms framework reference in GraphViewerGDI.nuspec

### DIFF
--- a/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
+++ b/GraphLayout/tools/GraphViewerGDI/GraphViewerGDI.nuspec
@@ -35,7 +35,16 @@
     </dependencies>
     <frameworkReferences>
       <group targetFramework="net6.0-windows7.0">
-        <frameworkReference name="Microsoft.WindowsDesktop.App.WinForms" />
+        <frameworkReference name="Microsoft.WindowsDesktop.App.WindowsForms" />
+      </group>
+      <group targetFramework="net8.0-windows7.0">
+        <frameworkReference name="Microsoft.WindowsDesktop.App.WindowsForms" />
+      </group>
+      <group targetFramework="net9.0-windows7.0">
+        <frameworkReference name="Microsoft.WindowsDesktop.App.WindowsForms" />
+      </group>
+      <group targetFramework="net10.0-windows7.0">
+        <frameworkReference name="Microsoft.WindowsDesktop.App.WindowsForms" />
       </group>
       
     </frameworkReferences>


### PR DESCRIPTION
Correct 'Microsoft.WindowsDesktop.App.WinForms' to the SDK-recognized 'Microsoft.WindowsDesktop.App.WindowsForms', resolving NETSDK1073 for consumers on the .NET 10 SDK (issue #390). Also declare the reference for all shipped Windows TFMs (net6/8/9/10).